### PR TITLE
Add lyrics.com fallback for lyric fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# lyrics_ai_1
+# Lyrics Fetcher
+
+Simple script to retrieve song lyrics. It first tries the
+[lyrics.ovh](https://lyrics.ovh) API and falls back to scraping
+[lyrics.com](https://www.lyrics.com) if necessary.
+
+## Usage
+
+Run the script and follow prompts for song title and artist:
+
+```bash
+python lyrics_fetcher.py
+```
+
+To avoid prompts, pass the title and artist as arguments:
+
+```bash
+python lyrics_fetcher.py "Mother" "Pink Floyd"
+```
+
+The script prints only the lyrics, with extra blank lines removed.
+Input prompts are written to stderr so that redirecting stdout captures just the lyrics.

--- a/lyrics_fetcher.py
+++ b/lyrics_fetcher.py
@@ -1,0 +1,111 @@
+from typing import Optional
+import argparse
+import json
+import sys
+import re
+import html
+import urllib.request
+import urllib.error
+import urllib.parse
+
+API_URL = "https://api.lyrics.ovh/v1/{artist}/{title}"
+
+
+def fetch_lyrics_ovh(title: str, artist: str, timeout: int = 10) -> Optional[str]:
+    """Fetch lyrics from the lyrics.ovh API."""
+    url = API_URL.format(
+        artist=urllib.parse.quote(artist),
+        title=urllib.parse.quote(title),
+    )
+    req = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status != 200:
+                return None
+            data = json.loads(resp.read().decode())
+            return data.get("lyrics")
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return None
+    return None
+
+
+def fetch_lyrics_lyricscom(title: str, artist: str, timeout: int = 10) -> Optional[str]:
+    """Fetch lyrics by scraping lyrics.com as a fallback."""
+    query = urllib.parse.quote(f"{title} {artist}")
+    search_url = f"https://www.lyrics.com/lyrics/{query}"
+    try:
+        with urllib.request.urlopen(search_url, timeout=timeout) as resp:
+            if resp.status != 200:
+                return None
+            search_html = resp.read().decode(errors="ignore")
+    except (urllib.error.URLError, TimeoutError):
+        return None
+
+    match = re.search(r'<td class="tal qx"><strong><a href="(/lyric/[^"?]+)"', search_html)
+    if not match:
+        return None
+
+    song_url = "https://www.lyrics.com" + match.group(1)
+    try:
+        with urllib.request.urlopen(song_url, timeout=timeout) as resp:
+            if resp.status != 200:
+                return None
+            song_html = resp.read().decode(errors="ignore")
+    except (urllib.error.URLError, TimeoutError):
+        return None
+
+    body = re.search(r'<pre id="lyric-body-text"[^>]*>(.*?)</pre>', song_html, re.S)
+    if not body:
+        return None
+    return html.unescape(body.group(1)).strip()
+
+
+def get_lyrics(title: str, artist: str, timeout: int = 10) -> Optional[str]:
+    """Return song lyrics from available sources."""
+    lyrics = fetch_lyrics_ovh(title, artist, timeout)
+    if lyrics:
+        return lyrics
+    return fetch_lyrics_lyricscom(title, artist, timeout)
+
+
+def clean_lyrics(text: str) -> str:
+    """Return lyrics stripped of surrounding whitespace and extra blank lines."""
+    lines = [line.rstrip() for line in text.splitlines()]
+    cleaned: list[str] = []
+    previous_blank = False
+    for line in lines:
+        is_blank = line == ""
+        if is_blank and previous_blank:
+            continue
+        cleaned.append(line)
+        previous_blank = is_blank
+    return "\n".join(cleaned).strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch song lyrics")
+    parser.add_argument("title", nargs="?", help="Song title")
+    parser.add_argument("artist", nargs="?", help="Song artist")
+    args = parser.parse_args()
+
+    if args.title:
+        title = args.title
+    else:
+        print("Song title: ", end="", file=sys.stderr)
+        title = input().strip()
+
+    if args.artist:
+        artist = args.artist
+    else:
+        print("Artist: ", end="", file=sys.stderr)
+        artist = input().strip()
+
+    lyrics = get_lyrics(title, artist)
+    if lyrics:
+        print(clean_lyrics(lyrics))
+    else:
+        print("Lyrics not found or service unavailable.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fall back to scraping lyrics.com when lyrics.ovh API fails
- Harden lyrics.ovh fetching with explicit status check and JSON decode handling to avoid crashes

## Testing
- `python -m py_compile lyrics_fetcher.py`
- `python lyrics_fetcher.py "Mother" "Pink Floyd"`
- `python lyrics_fetcher.py <<'EOF'
Imagine
John Lennon
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68adb57a908c8323994f75191c755b6c